### PR TITLE
TiKV integration fixes

### DIFF
--- a/src/homedb/core/src/index/btree_index.rs
+++ b/src/homedb/core/src/index/btree_index.rs
@@ -10,6 +10,7 @@ use homestore::index::btree::detail::btree_req::{BtreeKeyRange, GetFilter, PutFi
 pub trait IndexQueryHandle<K: 'static + BtreeKey, V: 'static + BtreeValue>: Send + std::any::Any {
     fn results(&self) -> &[(K, V)];
     fn has_more(&self) -> bool;
+    fn into_any_send(self: Box<Self>) -> Box<dyn std::any::Any + Send>;
 }
 
 /// Convert to Box<dyn Any> for downcast in query_next_batch. Requires IndexQueryHandle: Any.
@@ -19,7 +20,7 @@ pub trait IndexQueryHandle<K: 'static + BtreeKey, V: 'static + BtreeValue>: Send
 pub fn index_query_handle_into_any<K: 'static + BtreeKey, V: 'static + BtreeValue>(
     me: Box<dyn IndexQueryHandle<K, V>>,
 ) -> Box<dyn std::any::Any + Send> {
-    unsafe { Box::from_raw(Box::into_raw(me) as *mut (dyn std::any::Any + Send)) }
+    me.into_any_send()
 }
 
 #[cfg_attr(feature = "async_frontend", async_trait::async_trait)]

--- a/src/homedb/core/src/index/sharded_btree.rs
+++ b/src/homedb/core/src/index/sharded_btree.rs
@@ -196,6 +196,7 @@ impl<K: 'static + BtreeKey, V: 'static + BtreeValue> ShardedQueryHandle<K, V> {
 impl<K: 'static + BtreeKey, V: 'static + BtreeValue> IndexQueryHandle<K, V> for ShardedQueryHandle<K, V> {
     fn results(&self) -> &[(K, V)] { &self.results }
     fn has_more(&self) -> bool { self.has_more_impl() }
+    fn into_any_send(self: Box<Self>) -> Box<dyn std::any::Any + Send> { self }
 }
 
 fn to_sharded_query_handle<K: 'static + BtreeKey, V: 'static + BtreeValue>(

--- a/src/homedb/core/src/index/sharded_btree.rs
+++ b/src/homedb/core/src/index/sharded_btree.rs
@@ -97,7 +97,7 @@ macro_rules! shard_call {
 //==============================================================================
 
 fn bytes_to_part_id(bytes: &[u8], max_partitions: usize) -> u32 {
-    if max_partitions <= 1 { return 0; }
+    if max_partitions <= 1 || bytes.is_empty() { return 0; }
     // Interpret the leading (up to 16) bytes as a big-endian u128.
     // Shorter keys occupy the high bits; remaining bits are 0.
     // This preserves lexicographic order within the integer domain.
@@ -514,7 +514,12 @@ impl<K: 'static + Partitionable, V: 'static + BtreeValue> BtreeIndex<K, V> for S
         filter: Option<Arc<dyn GetFilter<K, V>>>,
         reverse: bool,
     ) -> Result<Box<dyn IndexQueryHandle<K, V>>, BtreeError> {
-        let partitions = self.route_range(&range);
+        let mut partitions = self.route_range(&range);
+        // For reverse queries, traverse partitions from highest to lowest
+        // so fill_query_handle visits the largest keys first.
+        if reverse {
+            partitions.reverse();
+        }
 
         let mut handle = ShardedQueryHandle {
             results: Vec::new(), input_range: range, batch_size, filter, reverse,

--- a/src/homedb/core/src/index/unsharded_btree.rs
+++ b/src/homedb/core/src/index/unsharded_btree.rs
@@ -36,6 +36,10 @@ impl<K: 'static + BtreeKey, V: 'static + BtreeValue> IndexQueryHandle<K, V> for 
     fn has_more(&self) -> bool {
         self.0.has_more()
     }
+ 
+    fn into_any_send(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        self
+    }
 }
 
 pub struct UnshardedBtree<K: 'static + BtreeKey, V: 'static + BtreeValue> {

--- a/src/homestore/Cargo.toml
+++ b/src/homestore/Cargo.toml
@@ -13,7 +13,7 @@ libc = "0.2"
 once_cell = "1.19"
 sisl = { path = "../sisl", optional = true }
 aligned-vec = "0.6"
-uuid = { version = "1.18.1", features = ["v4"] }
+uuid = { version = "1.18.1", features = ["v4"], optional = true }
 log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -29,7 +29,7 @@ bincode = "1.3"
 arc-swap = "1.6"
 dashmap = "6.0"
 futures = "0.3"
-crc = "3.0"
+crc = { version = "3.0", optional = true }
 triomphe = "0.1"
 bitfield = "0.14"
 bytemuck = { version = "1.14", features = ["derive"] }
@@ -53,7 +53,7 @@ path = "lib.rs"
 [features]
 # New unified feature flags for sync/async + inmem/persistent modes
 default = ["persistent", "btree-only", "async_code"]
-persistent = ["dep:iomgr", "dep:tokio"]  # Persistent mode requires iomanager and tokio
+persistent = ["dep:iomgr", "dep:tokio", "dep:uuid", "dep:crc"]  # Persistent mode requires iomanager and tokio
 inmem = []  # In-memory mode (btree only, no device layer)
 sync_code = []  # Sync mode (strips async/await, uses sync locks)
 async_code = ["dep:iomgr", "dep:tokio", "dep:async-recursion"]  # Async mode (uses async locks, iomanager, and tokio runtime)

--- a/src/homestore/index/btree/variant/varlen_node_common.rs
+++ b/src/homestore/index/btree/variant/varlen_node_common.rs
@@ -32,6 +32,7 @@ use super::super::btree_kvs::{BtreeKey, BtreeValue, ValueOrOverflow};
 use super::super::btree_types::BtreeError;
 use super::super::detail::btree_req::BtreePutType;
 use std::io;
+use std::mem::size_of;
 
 //================================================================================
 // Variable-Length Node Header


### PR DESCRIPTION
## Summary
- Fix empty-key panic and reverse query partition ordering in sharded B-tree
- Make some changes to dependencies and fix casts a raw pointer between two different trait objects (dyn IndexQueryHandle → dyn Any + Send).

## Changes
- bytes_to_part_id: return partition 0 for empty keys to avoid shift-left overflow (128-bit shift on u128)
- query: reverse partition traversal order when reverse=true so that seek_to_last and reverse iterators visit highest-key shards first
- Each trait object is a fat pointer: (data_ptr, vtable_ptr). The vtable for dyn IndexQueryHandle and the vtable for dyn Any + Send are different tables — different function pointers, different layouts. The raw pointer cast just reinterprets the bits without changing the vtable, which is undefined behavior. Rust 1.77 rejects this with error E0606: "vtable kinds may not match".

## Testing Done
Successfully built and ran all the tests